### PR TITLE
feat: add csrf token endpoint

### DIFF
--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -9,7 +9,7 @@ import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Eye, EyeOff, Mail, Lock } from "lucide-react";
 import { loginSchema, type LoginCredentials } from "@shared/schema";
-import { apiRequest } from "@/lib/queryClient";
+import { apiRequest, getCsrfToken } from "@/lib/queryClient";
 import baseSolutionLogo from "@assets/Logo BS COL_1756425179703.jpg";
 
 interface LoginResponse {
@@ -41,33 +41,9 @@ export default function Login({ onLoginSuccess }: LoginPageProps) {
   const loginMutation = useMutation({
     mutationFn: async (credentials: LoginCredentials): Promise<LoginResponse> => {
       console.log('🚀 Attempting login with:', { email: credentials.email, password: '[HIDDEN]' });
-      
-      // Direct fetch without apiRequest to isolate the issue
-      const response = await fetch('/api/auth/login', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(credentials),
-        credentials: 'include'
-      });
-      
-      console.log('📡 Response received:', { status: response.status, ok: response.ok });
-      
-      
-      if (!response.ok) {
-        const errorText = await response.text();
-        console.error('Login failed with status:', response.status, 'Error:', errorText);
-        
-        // Parse error message from server
-        try {
-          const errorData = JSON.parse(errorText);
-          throw new Error(errorData.error || 'Error de login');
-        } catch {
-          throw new Error('Error de conexión con el servidor');
-        }
-      }
-      
+
+      await getCsrfToken(true);
+      const response = await apiRequest('POST', '/api/auth/login', credentials);
       const data = await response.json();
       return data;
     },

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -52,7 +52,7 @@ const upload = multer({
 });
 
 export async function registerRoutes(app: Express): Promise<Server> {
-  
+
   // Deployment diagnostic endpoint
   app.get("/api/health", (req, res) => {
     const isDeployment = !!(process.env.REPL_DEPLOYMENT || 
@@ -76,7 +76,14 @@ export async function registerRoutes(app: Express): Promise<Server> {
       timestamp: new Date().toISOString()
     });
   });
-  
+
+  // CSRF token endpoint
+  app.get('/api/csrf-token', (req, res) => {
+    const token = req.csrfToken();
+    res.set('X-CSRF-Token', token);
+    res.json({ csrfToken: token });
+  });
+
   // Authentication routes
   app.post("/api/auth/login", async (req, res) => {
     try {


### PR DESCRIPTION
## Summary
- expose CSRF token via new `/api/csrf-token` endpoint
- include `X-CSRF-Token` header in `apiRequest` helper
- fetch CSRF token before login and reuse helper for authentication

## Testing
- `npm test` *(fails: Your test suite must contain at least one test)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b5ed871c832b822c744203def6e3