### PR TITLE
Avoid rethrowing errors in Express middleware

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -81,8 +81,8 @@ app.use((req, res, next) => {
     const status = err.status || err.statusCode || 500;
     const message = err.message || "Internal Server Error";
 
+    log.error(err);
     res.status(status).json({ message });
-    throw err;
   });
 
   // Configurar Vite en desarrollo


### PR DESCRIPTION
## Summary
- Log errors in global Express error handler instead of rethrowing

## Testing
- `npm test` *(fails: process hangs without completing)*
- `npm run check` *(fails: File '/workspace/control_bancolombia/server/utils/swagger.ts' is not a module)*
- `npm run dev` *(fails: SyntaxError: The requested module './utils/swagger' does not provide an export named 'setupSwagger')*

------
https://chatgpt.com/codex/tasks/task_e_68b5b5f47f9c832bb307522a3f844341